### PR TITLE
test: add Velocity boot matrix integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ runs/
 modrinth_token.txt
 hangar_api_key.txt
 docs/site/
+bin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,25 +73,41 @@ spotless {
 
 tasks {
     test {
-        useJUnitPlatform()
+        useJUnitPlatform {
+            if (project.hasProperty("fastTests")) {
+                excludeTags("velocity-boot")
+            }
+        }
+        // VelocityBootIT boots a real Velocity proxy with the relocated jar.
+        dependsOn(shadowJar)
+        systemProperty(
+            "autostartstop.jar",
+            shadowJar.get().archiveFile.get().asFile.absolutePath
+        )
+        // Integration tests touch external resources (PaperMC API + on-disk velocity-cache)
+        // that Gradle can't snapshot, so its UP-TO-DATE check would silently skip real
+        // execution. Force re-run unless the user opts out of integration tests.
+        if (!project.hasProperty("fastTests")) {
+            outputs.upToDateWhen { false }
+        }
     }
-    
+
     withType<JavaCompile>().configureEach {
         options.encoding = "UTF-8"
     }
-    
+
     shadowJar {
         archiveFileName = "${project.name}-${project.version}.jar"
         archiveClassifier = ""
-        
+
         // Relocate to avoid conflicts with other plugins
         relocate("org.bstats", "${project.group}.bstats")
     }
-    
+
     jar {
         enabled = false
     }
-    
+
     build {
         dependsOn(shadowJar)
     }

--- a/src/test/java/com/autostartstop/integration/VelocityBootIT.java
+++ b/src/test/java/com/autostartstop/integration/VelocityBootIT.java
@@ -1,0 +1,178 @@
+package com.autostartstop.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.autostartstop.Constants;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Boots a real Velocity proxy with the relocated AutoStartStop shadowJar across a matrix of
+ * Velocity versions and asserts the plugin loads and finishes its own startup lifecycle without
+ * errors.
+ *
+ * <p>Runs as part of {@code ./gradlew test}. Use {@code ./gradlew test -PfastTests} during fast
+ * iteration to skip this class via the {@code velocity-boot} tag. Cached Velocity downloads live in
+ * {@code build/velocity-cache}; clean it (or run {@code ./gradlew clean}) to refresh.
+ *
+ * <p>Matrix (each row is a {@code (version, build)} pair, resolved against PaperMC's Fill v3 API):
+ *
+ * <ul>
+ *   <li>{@code 3.4.0 / 566} — stated minimum supported version (vanilla 3.4.0 install).
+ *   <li>{@code 3.5.0-SNAPSHOT / 595} — latest 3.5 build, pinned for reproducibility.
+ *   <li>{@code latest / latest} — bleeding edge; resolved at run time and tracks newer version
+ *       families automatically.
+ * </ul>
+ */
+@Tag("velocity-boot")
+class VelocityBootIT {
+
+  /**
+   * Matches Velocity log lines that indicate a plugin lifecycle failure: Velocity's own {@code
+   * VelocityPluginManager} errors and the plugin's catch-all in {@link
+   * com.autostartstop.AutoStartStop#onProxyInitialization}.
+   */
+  private static final Pattern PLUGIN_LIFECYCLE_FAILURE =
+      Pattern.compile(
+          "(Can't load plugin|Error loading plugin|Unable to load plugin|The server will shut down|Can't create plugin|Failed to enable AutoStartStop)",
+          Pattern.CASE_INSENSITIVE);
+
+  /**
+   * Matches the {@code ConfigLoader} summary line, capturing the number of rules parsed. We assert
+   * this matches the number of rules in {@link #COVERAGE_CONFIG_RESOURCE}, which proves every rule
+   * survived YAML parsing. Activation failures (per-rule) are caught separately by {@link
+   * #PLUGIN_LIFECYCLE_FAILURE}.
+   */
+  private static final Pattern CONFIG_LOADED =
+      Pattern.compile("Configuration loaded \\([^)]*rules:\\s*(\\d+)[^)]*\\)");
+
+  /** Velocity logs this when its plugin manager has accepted and instantiated the plugin. */
+  private static final String VELOCITY_LOAD_LINE = "Loaded plugin " + Constants.PLUGIN_ID;
+
+  /**
+   * The plugin's own end-of-init log line — proves {@code onProxyInitialization} ran to completion
+   * without throwing. See {@code AutoStartStop.java}.
+   */
+  private static final String PLUGIN_READY_LINE = "AutoStartStop enabled successfully";
+
+  private static final Duration BOOT_TIMEOUT = Duration.ofSeconds(120);
+  private static final Duration ASYNC_ACTION_TIMEOUT = Duration.ofSeconds(15);
+
+  /**
+   * Test fixture seeded into {@code <runDirectory>/plugins/autostartstop/config.yml} before each
+   * boot — see {@code src/test/resources/integration/coverage-config.yml}. The shipped default
+   * config has every rule {@code enabled: false}, which means none of the trigger event
+   * subscriptions exercise the Velocity event API surface. This config flips that on.
+   */
+  private static final String COVERAGE_CONFIG_RESOURCE = "integration/coverage-config.yml";
+
+  /**
+   * Number of rules defined in {@link #COVERAGE_CONFIG_RESOURCE} — one per trigger type the plugin
+   * supports. Used to verify the {@code Configuration loaded ... rules: N} log line agrees.
+   */
+  private static final int COVERAGE_RULE_COUNT = 7;
+
+  /**
+   * Substring of the log line that the {@code cov_proxy_start} rule's {@code log} action emits when
+   * the rule executor runs it during boot. Catches breakage in the trigger → rule executor → action
+   * execution pipeline that registration alone wouldn't.
+   */
+  private static final String PROXY_START_ACTION_MARKER = "coverage:proxy_start";
+
+  @ParameterizedTest(name = "Velocity {0} build {1}")
+  @CsvSource({
+    "3.4.0,           566",
+    "3.5.0-SNAPSHOT,  595",
+    "latest,          latest",
+  })
+  void pluginLoadsAgainstVelocity(String version, String build, @TempDir Path runDirectory)
+      throws Exception {
+    Path velocityJar = VelocityJarResolver.resolve(version, build);
+    Path pluginJar = locatePluginJar();
+    seedPluginConfig(runDirectory, COVERAGE_CONFIG_RESOURCE);
+
+    try (VelocityProcess proxy = VelocityProcess.start(velocityJar, pluginJar, runDirectory)) {
+      proxy.awaitReady(BOOT_TIMEOUT);
+      // Wait for the proxy_start rule's async LogAction to complete. The rule executor runs
+      // actions on its own thread pool, so this log line normally arrives after "Done (X.XXs)!".
+      proxy.awaitLogContains(PROXY_START_ACTION_MARKER, ASYNC_ACTION_TIMEOUT);
+      String logs = proxy.dumpLogs();
+
+      assertTrue(
+          logs.contains(VELOCITY_LOAD_LINE),
+          () ->
+              "Velocity did not log '"
+                  + VELOCITY_LOAD_LINE
+                  + "' — plugin metadata may be invalid or jar may be malformed.\n\n"
+                  + logs);
+
+      assertTrue(
+          logs.contains(PLUGIN_READY_LINE),
+          () ->
+              "Plugin did not log '"
+                  + PLUGIN_READY_LINE
+                  + "' — onProxyInitialization did not run to completion.\n\n"
+                  + logs);
+
+      Matcher rulesMatch = CONFIG_LOADED.matcher(logs);
+      assertTrue(
+          rulesMatch.find(),
+          () -> "ConfigLoader did not log a 'Configuration loaded' summary.\n\n" + logs);
+      int parsedRules = Integer.parseInt(rulesMatch.group(1));
+      assertEquals(
+          COVERAGE_RULE_COUNT,
+          parsedRules,
+          () ->
+              "ConfigLoader parsed "
+                  + parsedRules
+                  + " rules, expected "
+                  + COVERAGE_RULE_COUNT
+                  + " — coverage config may be malformed for this Velocity build.\n\n"
+                  + logs);
+
+      Matcher failure = PLUGIN_LIFECYCLE_FAILURE.matcher(logs);
+      assertFalse(
+          failure.find(),
+          () ->
+              "Velocity logged a plugin lifecycle failure ("
+                  + (failure.hitEnd() ? "<unknown>" : failure.group())
+                  + ").\n\n"
+                  + logs);
+    }
+  }
+
+  private static void seedPluginConfig(Path runDirectory, String resource) throws IOException {
+    Path target = runDirectory.resolve("plugins/autostartstop/config.yml");
+    Files.createDirectories(target.getParent());
+    try (InputStream in = VelocityBootIT.class.getClassLoader().getResourceAsStream(resource)) {
+      if (in == null) {
+        throw new IOException("Test resource not found on classpath: " + resource);
+      }
+      Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+  private static Path locatePluginJar() {
+    String jarProp = System.getProperty("autostartstop.jar");
+    assertNotNull(
+        jarProp,
+        "System property 'autostartstop.jar' must be set by the Gradle test task. Run via "
+            + "./gradlew test rather than invoking JUnit directly.");
+    Path jar = Path.of(jarProp);
+    assertTrue(Files.isRegularFile(jar), "AutoStartStop shadowJar not found at " + jar);
+    return jar;
+  }
+}

--- a/src/test/java/com/autostartstop/integration/VelocityJarResolver.java
+++ b/src/test/java/com/autostartstop/integration/VelocityJarResolver.java
@@ -1,0 +1,125 @@
+package com.autostartstop.integration;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Downloads Velocity proxy jars from PaperMC's Fill v3 API and caches them on disk so subsequent
+ * test runs reuse the same artifact.
+ *
+ * <p>PaperMC does not publish proxy jars to a Maven repository — only the API artifact is on Maven.
+ * The proxy itself is only served via {@code https://fill.papermc.io/v3/...} (which in turn
+ * redirects to a content-addressed {@code fill-data.papermc.io} URL), so the integration tests
+ * fetch them directly.
+ *
+ * <p>Both {@code version} and {@code build} accept the literal {@code "latest"} sentinel:
+ *
+ * <ul>
+ *   <li>{@code version="latest"} resolves to the highest version in the {@code 3.0.0} family.
+ *   <li>{@code build="latest"} resolves to the highest build of the chosen version.
+ * </ul>
+ */
+final class VelocityJarResolver {
+
+  private static final String API_BASE = "https://fill.papermc.io/v3/projects/velocity";
+  private static final Path CACHE_DIR = Path.of("build", "velocity-cache");
+  private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+
+  /** The modern Velocity family this resolver targets when {@code version="latest"}. */
+  private static final String VERSION_FAMILY = "3.0.0";
+
+  private static final Pattern URL_FIELD = Pattern.compile("\"url\"\\s*:\\s*\"([^\"]+)\"");
+  private static final Pattern NAME_FIELD =
+      Pattern.compile("\"name\"\\s*:\\s*\"(velocity-[^\"]+\\.jar)\"");
+
+  private record BuildArtifact(String fileName, String downloadUrl) {}
+
+  private VelocityJarResolver() {}
+
+  /**
+   * Returns a path to the Velocity jar for the given {@code version} and {@code build}, downloading
+   * it on first request.
+   *
+   * @param version a Velocity version string (e.g. {@code "3.4.0"}, {@code "3.5.0-SNAPSHOT"}) or
+   *     the literal {@code "latest"}
+   * @param build a numeric build id (e.g. {@code "566"}) or the literal {@code "latest"}
+   */
+  static Path resolve(String version, String build) throws IOException, InterruptedException {
+    Files.createDirectories(CACHE_DIR);
+    String resolvedVersion = "latest".equals(version) ? fetchLatestVersion() : version;
+    BuildArtifact artifact = fetchBuildArtifact(resolvedVersion, build);
+    Path target = CACHE_DIR.resolve(artifact.fileName);
+    if (Files.isRegularFile(target) && Files.size(target) > 0) {
+      return target;
+    }
+    download(URI.create(artifact.downloadUrl), target);
+    return target;
+  }
+
+  private static String fetchLatestVersion() throws IOException, InterruptedException {
+    URI uri = URI.create(API_BASE);
+    String body = httpGetText(uri);
+    // Family blocks list versions newest-first, e.g. "3.0.0": ["3.5.0-SNAPSHOT", "3.4.0", ...].
+    Pattern familyVersions =
+        Pattern.compile("\"" + Pattern.quote(VERSION_FAMILY) + "\"\\s*:\\s*\\[\\s*\"([^\"]+)\"");
+    Matcher m = familyVersions.matcher(body);
+    if (!m.find()) {
+      throw new IOException(
+          "Could not find '" + VERSION_FAMILY + "' family in PaperMC response: " + body);
+    }
+    return m.group(1);
+  }
+
+  private static BuildArtifact fetchBuildArtifact(String version, String build)
+      throws IOException, InterruptedException {
+    URI uri = URI.create(API_BASE + "/versions/" + version + "/builds/" + build);
+    String body = httpGetText(uri);
+    Matcher nameMatch = NAME_FIELD.matcher(body);
+    Matcher urlMatch = URL_FIELD.matcher(body);
+    if (!nameMatch.find() || !urlMatch.find()) {
+      throw new IOException("Could not parse build artifact from " + uri + ": " + body);
+    }
+    return new BuildArtifact(nameMatch.group(1), urlMatch.group(1));
+  }
+
+  private static void download(URI uri, Path target) throws IOException, InterruptedException {
+    Path tmp = Files.createTempFile(target.getParent(), "velocity-", ".part");
+    try {
+      HttpRequest request = HttpRequest.newBuilder(uri).timeout(HTTP_TIMEOUT).GET().build();
+      HttpResponse<Path> response =
+          newHttpClient().send(request, HttpResponse.BodyHandlers.ofFile(tmp));
+      if (response.statusCode() != 200) {
+        throw new IOException("Failed to download " + uri + ": HTTP " + response.statusCode());
+      }
+      Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+    } finally {
+      Files.deleteIfExists(tmp);
+    }
+  }
+
+  private static String httpGetText(URI uri) throws IOException, InterruptedException {
+    HttpRequest request = HttpRequest.newBuilder(uri).timeout(HTTP_TIMEOUT).GET().build();
+    HttpResponse<String> response =
+        newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IOException("HTTP " + response.statusCode() + " for " + uri);
+    }
+    return response.body();
+  }
+
+  private static HttpClient newHttpClient() {
+    return HttpClient.newBuilder()
+        .connectTimeout(HTTP_TIMEOUT)
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .build();
+  }
+}

--- a/src/test/java/com/autostartstop/integration/VelocityProcess.java
+++ b/src/test/java/com/autostartstop/integration/VelocityProcess.java
@@ -1,0 +1,191 @@
+package com.autostartstop.integration;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
+
+/**
+ * A handle to a real Velocity proxy running as a child process.
+ *
+ * <p>Spawns Velocity from a downloaded jar with the plugin under test mounted into {@code
+ * plugins/}, captures merged stdout/stderr asynchronously, and exposes a blocking {@link
+ * #awaitReady} that returns once Velocity logs its boot-complete line. {@link #close} requests a
+ * graceful shutdown via Velocity's {@code end} console command, falling back to {@code
+ * destroyForcibly} if the proxy does not exit in time.
+ */
+final class VelocityProcess implements AutoCloseable {
+
+  /**
+   * Velocity logs its boot-complete line as {@code Done (X.XXs)!}. The decimal separator is
+   * locale-sensitive ({@code DecimalFormat} default), so accept both '.' and ','.
+   */
+  private static final Pattern READY_PATTERN = Pattern.compile(".*Done \\([0-9.,]+s\\)!.*");
+
+  private static final Duration SHUTDOWN_GRACE = Duration.ofSeconds(15);
+  private static final Duration LOG_READER_JOIN = Duration.ofSeconds(2);
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
+
+  private final Process process;
+  private final List<String> logs = new CopyOnWriteArrayList<>();
+  private final Thread logReader;
+
+  private VelocityProcess(Process process) {
+    this.process = process;
+    this.logReader = new Thread(this::pumpLogs, "velocity-log-reader");
+    this.logReader.setDaemon(true);
+    this.logReader.start();
+  }
+
+  /**
+   * Boots Velocity in {@code runDirectory} with {@code pluginJar} mounted at {@code
+   * <runDirectory>/plugins/}.
+   */
+  static VelocityProcess start(Path velocityJar, Path pluginJar, Path runDirectory)
+      throws IOException {
+    Path pluginsDir = runDirectory.resolve("plugins");
+    Files.createDirectories(pluginsDir);
+    Files.copy(
+        pluginJar,
+        pluginsDir.resolve(pluginJar.getFileName()),
+        StandardCopyOption.REPLACE_EXISTING);
+
+    String javaBin =
+        Path.of(System.getProperty("java.home"), "bin", "java").toAbsolutePath().toString();
+    ProcessBuilder pb =
+        new ProcessBuilder(
+            javaBin,
+            "-Xms128M",
+            "-Xmx256M",
+            // SimpleTerminalConsole probes for a real TTY; suppress JLine to keep logs plain text.
+            "-Dterminal.jline=false",
+            "-Dterminal.ansi=false",
+            "-jar",
+            velocityJar.toAbsolutePath().toString());
+    pb.directory(runDirectory.toFile());
+    pb.redirectErrorStream(true);
+    return new VelocityProcess(pb.start());
+  }
+
+  private void pumpLogs() {
+    try (BufferedReader r =
+        new BufferedReader(
+            new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = r.readLine()) != null) {
+        logs.add(line);
+      }
+    } catch (IOException ignored) {
+      // process exited; pump is done
+    }
+  }
+
+  /**
+   * Blocks until Velocity logs its boot-complete line, the process exits early, or the timeout
+   * elapses.
+   */
+  void awaitReady(Duration timeout) throws InterruptedException, TimeoutException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      for (String line : logs) {
+        if (READY_PATTERN.matcher(line).matches()) {
+          return;
+        }
+      }
+      if (!process.isAlive()) {
+        throw new IllegalStateException(
+            "Velocity exited before ready (exit="
+                + process.exitValue()
+                + "). Logs:\n"
+                + dumpLogs());
+      }
+      Thread.sleep(POLL_INTERVAL.toMillis());
+    }
+    throw new TimeoutException(
+        "Velocity did not boot within " + timeout + ". Logs:\n" + dumpLogs());
+  }
+
+  /**
+   * Blocks until any captured log line contains {@code substring}, or the timeout elapses. Useful
+   * for asserting on output produced asynchronously by the rule executor after {@link #awaitReady}
+   * has already returned.
+   */
+  void awaitLogContains(String substring, Duration timeout)
+      throws InterruptedException, TimeoutException {
+    long deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      for (String line : logs) {
+        if (line.contains(substring)) {
+          return;
+        }
+      }
+      Thread.sleep(POLL_INTERVAL.toMillis());
+    }
+    throw new TimeoutException(
+        "Log line containing '"
+            + substring
+            + "' did not appear within "
+            + timeout
+            + ". Logs:\n"
+            + dumpLogs());
+  }
+
+  /** Returns a snapshot of all log lines captured so far, joined by newlines. */
+  String dumpLogs() {
+    return String.join("\n", logs);
+  }
+
+  /** Returns a snapshot of the captured log lines. */
+  List<String> logs() {
+    return new ArrayList<>(logs);
+  }
+
+  @Override
+  public void close() {
+    if (process.isAlive()) {
+      sendEndCommand();
+      waitForGracefulExit();
+    }
+    joinLogReader();
+  }
+
+  private void sendEndCommand() {
+    try (OutputStream stdin = process.getOutputStream()) {
+      stdin.write("end\n".getBytes(StandardCharsets.UTF_8));
+      stdin.flush();
+    } catch (IOException ignored) {
+      // best effort — proxy may already be exiting
+    }
+  }
+
+  private void waitForGracefulExit() {
+    try {
+      if (!process.waitFor(SHUTDOWN_GRACE.toSeconds(), TimeUnit.SECONDS)) {
+        process.destroyForcibly();
+        process.waitFor(5, TimeUnit.SECONDS);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      process.destroyForcibly();
+    }
+  }
+
+  private void joinLogReader() {
+    try {
+      logReader.join(LOG_READER_JOIN.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/test/resources/integration/coverage-config.yml
+++ b/src/test/resources/integration/coverage-config.yml
@@ -1,0 +1,79 @@
+# ============================================================================
+# Integration test coverage config.
+#
+# Forces the plugin to register an event subscription for every supported
+# trigger type during boot, so VelocityBootIT catches breaking changes in any
+# Velocity event class (LoginEvent, ProxyPingEvent, etc.) — not just the
+# ProxyInitializeEvent that the plugin's main class subscribes to directly.
+#
+# cov_proxy_start uses a `log` action with a fixed message so we can assert that
+# the proxy_start trigger's full path (trigger -> rule executor -> action
+# execution) actually runs.
+# ============================================================================
+
+version: 1
+
+settings:
+  shutdown_timeout: 5s
+  check_for_updates: false
+
+servers: {}
+
+rules:
+  cov_proxy_start:
+    enabled: true
+    triggers:
+      - proxy_start:
+    action:
+      - log:
+          message: "coverage:proxy_start"
+
+  cov_proxy_shutdown:
+    enabled: true
+    triggers:
+      - proxy_shutdown:
+    action:
+      - log:
+          message: "coverage:proxy_shutdown"
+
+  cov_connection:
+    enabled: true
+    triggers:
+      - connection:
+    action:
+      - log:
+          message: "coverage:connection"
+
+  cov_empty_server:
+    enabled: true
+    triggers:
+      - empty_server:
+    action:
+      - log:
+          message: "coverage:empty_server"
+
+  cov_cron:
+    enabled: true
+    triggers:
+      - cron:
+          expression: "0 0 * * *"
+    action:
+      - log:
+          message: "coverage:cron"
+
+  cov_ping:
+    enabled: true
+    triggers:
+      - ping:
+    action:
+      - log:
+          message: "coverage:ping"
+
+  cov_manual:
+    enabled: true
+    triggers:
+      - manual:
+          id: "cov_test"
+    action:
+      - log:
+          message: "coverage:manual"


### PR DESCRIPTION
Boots real Velocity 3.4.0 / 3.5.0-SNAPSHOT / latest against the shadowJar and asserts plugin load, trigger registration, and the proxy_start action pipeline. Skip locally with `-PfastTests`.